### PR TITLE
fix: fix ignored end of line

### DIFF
--- a/lua/undo-glow/utils.lua
+++ b/lua/undo-glow/utils.lua
@@ -32,8 +32,8 @@ function M.sanitize_coords(bufnr, s_row, s_col, e_row, e_col)
 	if s_row < 0 then
 		s_row = 0
 	end
-	if s_row >= line_count then
-		s_row = line_count - 1
+	if s_row > line_count then
+		s_row = line_count
 	end
 
 	-- Clamp s_col
@@ -54,8 +54,8 @@ function M.sanitize_coords(bufnr, s_row, s_col, e_row, e_col)
 	if e_row < s_row then
 		e_row = s_row
 	end
-	if e_row >= line_count then
-		e_row = line_count - 1
+	if e_row > line_count then
+		e_row = line_count
 	end
 
 	-- Clamp e_col


### PR DESCRIPTION
### Problem

When redo or undo, if the last line is included it will be ignored.

![image](https://github.com/user-attachments/assets/4410d7c8-a00e-48ed-bc0c-fdfa5257bd95)

### Solution

Do not remove one line in `sanitize_coords` if last line for both `s_row` and `e_row`