### PR TITLE
feat!: Move highlights config into table

### DIFF
--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -105,20 +105,7 @@ Here is the default configuration:
     ---@field animation_type? AnimationType
     ---@field easing? function A function that takes a number (0-1) and returns a number (0-1) for easing.
     ---@field fps? number
-    ---@field undo_hl? string
-    ---@field redo_hl? string
-    ---@field yank_hl? string
-    ---@field paste_below_hl? string
-    ---@field paste_above_hl? string
-    ---@field search_next_hl? string
-    ---@field search_prev_hl? string
-    ---@field undo_hl_color? UndoGlow.HlColor
-    ---@field redo_hl_color? UndoGlow.HlColor
-    ---@field yank_hl_color? UndoGlow.HlColor
-    ---@field paste_below_hl_color? UndoGlow.HlColor
-    ---@field paste_above_hl_color? UndoGlow.HlColor
-    ---@field search_next_hl_color? UndoGlow.HlColor
-    ---@field search_prev_hl_color? UndoGlow.HlColor
+    ---@field highlights? table<"undo" | "redo" | "yank" | "paste_below" | "paste_above" | "search_next" | "search_prev", { hl: string, hl_color: UndoGlow.HlColor }>
     
     ---@class UndoGlow.HlColor
     ---@field bg string Background color
@@ -129,20 +116,36 @@ Here is the default configuration:
      animation_type = "fade", -- default to "fade"
      fps = 120, -- change the fps, normally either 60 / 120
      easing = M.easing.ease_in_out_cubic, -- see more at easing section on how to change and create your own
-     undo_hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
-     redo_hl = "UgRedo", -- Same as above
-     yank_hl = "UgYank", -- Same as above
-     paste_below_hl = "UgPasteBelow", -- Same as above
-     paste_above_hl = "UgPasteAbove", -- Same as above
-     search_next_hl = "UgSearchNext", -- Same as above
-     search_prev_hl = "UgSearchPrev", -- Same as above
-     undo_hl_color = { bg = "#FF5555" }, -- Colors from undo_hl will overwrite this, unless undo_hl does not contain the bg or fg. Ugly red color, please change it!
-     redo_hl_color = { bg = "#50FA7B" }, -- -- Same as above
-     yank_hl_color = { bg = "#F1FA8C" }, -- -- Same as above
-     paste_below_hl_color = { bg = "#8BE9FD" }, -- -- Same as above
-     paste_above_hl_color = { bg = "#BD93F9" }, -- -- Same as above
-     search_next_hl_color = { bg = "#FFB86C" }, -- -- Same as above
-     search_prev_hl_color = { bg = "#FF79C6" }, -- -- Same as above
+    highlights = { -- Any keys other than these defaults will be ignored and omitted
+     undo = {
+      hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
+      hl_color = { bg = "#FF5555" }, -- Ugly red color
+     },
+     redo = {
+      hl = "UgRedo", -- Same as above
+      hl_color = { bg = "#50FA7B" }, -- Ugly green color
+     },
+     yank = {
+      hl = "UgYank", -- Same as above
+      hl_color = { bg = "#F1FA8C" }, -- Ugly yellow color
+     },
+     paste_below = {
+      hl = "UgPasteBelow", -- Same as above
+      hl_color = { bg = "#8BE9FD" }, -- Ugly cyan color
+     },
+     paste_above = {
+      hl = "UgPasteAbove", -- Same as above
+      hl_color = { bg = "#BD93F9" }, -- Ugly purple color
+     },
+     search_next = {
+      hl = "UgSearchNext", -- Same as above
+      hl_color = { bg = "#FFB86C" }, -- Ugly orange color
+     },
+     search_prev = {
+      hl = "UgSearchPrev", -- Same as above
+      hl_color = { bg = "#FF79C6" }, -- Ugly pink color
+     },
+    },
     }
 <
 
@@ -430,9 +433,30 @@ HOW I SET IT UP? ~
       event = { "VeryLazy" },
       ---@type UndoGlow.Config
       opts = {
-       undo_hl = "DiffDelete",
-       redo_hl = "DiffAdd",
        duration = 1000,
+       highlights = {
+        undo = {
+         hl_color = { bg = "#48384B" },
+        },
+        redo = {
+         hl_color = { bg = "#3B474A" },
+        },
+        yank = {
+         hl_color = { bg = "#5A513C" },
+        },
+        paste_below = {
+         hl_color = { bg = "#5A496E" },
+        },
+        paste_above = {
+         hl_color = { bg = "#6D4B5E" },
+        },
+        search_next = {
+         hl_color = { bg = "#6D5640" },
+        },
+        search_prev = {
+         hl_color = { bg = "#3E4C63" },
+        },
+       },
       },
       ---@param _ any
       ---@param opts UndoGlow.Config
@@ -441,25 +465,17 @@ HOW I SET IT UP? ~
     
        undo_glow.setup(opts)
     
-       -- I like to use U to redo instead
-       vim.keymap.set("n", "U", "<C-r>", { noremap = true, silent = true })
+       vim.keymap.set("n", "u", require("undo-glow").undo, { noremap = true, silent = true })
+       vim.keymap.set("n", "U", require("undo-glow").redo, { noremap = true, silent = true })
+       vim.keymap.set("n", "p", require("undo-glow").paste_below, { noremap = true, silent = true })
+       vim.keymap.set("n", "P", require("undo-glow").paste_above, { noremap = true, silent = true })
+       vim.keymap.set("n", "n", require("undo-glow").search_next, { noremap = true, silent = true })
+       vim.keymap.set("n", "N", require("undo-glow").search_prev, { noremap = true, silent = true })
     
-       -- Highlight everything that changes
-       vim.api.nvim_create_autocmd({ "BufReadPost", "TextChanged" }, {
-        pattern = "*",
-        callback = function()
-         if vim.bo.buftype ~= "" then
-          return
-         end
-    
-         vim.schedule(function()
-          undo_glow.attach_and_run({
-           hlgroup = "UgUndo",
-          })
-         end)
-        end,
+       vim.api.nvim_create_autocmd("TextYankPost", {
+        desc = "Highlight when yanking (copying) text",
+        callback = require("undo-glow").yank,
        })
-      end,
      },
     }
 <

--- a/lua/undo-glow/config.lua
+++ b/lua/undo-glow/config.lua
@@ -5,20 +5,36 @@ local config = {
 	animation_type = "fade",
 	easing = require("undo-glow.easing").ease_in_out_cubic,
 	fps = 120,
-	undo_hl = "UgUndo",
-	redo_hl = "UgRedo",
-	yank_hl = "UgYank",
-	paste_below_hl = "UgPasteBelow",
-	paste_above_hl = "UgPasteAbove",
-	search_next_hl = "UgSearchNext",
-	search_prev_hl = "UgSearchPrev",
-	undo_hl_color = require("undo-glow.color").default_undo,
-	redo_hl_color = require("undo-glow.color").default_redo,
-	yank_hl_color = require("undo-glow.color").default_yank,
-	paste_below_hl_color = require("undo-glow.color").default_paste_below,
-	paste_above_hl_color = require("undo-glow.color").default_paste_above,
-	search_next_hl_color = require("undo-glow.color").default_search_next,
-	search_prev_hl_color = require("undo-glow.color").default_search_prev,
+	highlights = {
+		undo = {
+			hl = "UgUndo",
+			hl_color = require("undo-glow.color").default_undo,
+		},
+		redo = {
+			hl = "UgRedo",
+			hl_color = require("undo-glow.color").default_redo,
+		},
+		yank = {
+			hl = "UgYank",
+			hl_color = require("undo-glow.color").default_yank,
+		},
+		paste_below = {
+			hl = "UgPasteBelow",
+			hl_color = require("undo-glow.color").default_paste_below,
+		},
+		paste_above = {
+			hl = "UgPasteAbove",
+			hl_color = require("undo-glow.color").default_paste_above,
+		},
+		search_next = {
+			hl = "UgSearchNext",
+			hl_color = require("undo-glow.color").default_search_next,
+		},
+		search_prev = {
+			hl = "UgSearchPrev",
+			hl_color = require("undo-glow.color").default_search_prev,
+		},
+	},
 }
 
 return config

--- a/lua/undo-glow/init.lua
+++ b/lua/undo-glow/init.lua
@@ -7,20 +7,7 @@ local M = {}
 ---@field animation_type? AnimationType
 ---@field easing? function A function that takes a number (0-1) and returns a number (0-1) for easing.
 ---@field fps? number Normally either 60 / 120, up to you
----@field undo_hl? string If not "UgUndo" then copy the to color to UgUndo or fallback to default
----@field redo_hl? string If not "UgRedo" then copy the to color to UgRedo or fallback to default
----@field yank_hl? string If not "UgYank" then copy the to color to UgYank or fallback to default
----@field paste_below_hl? string If not "UgPasteBelow" then copy the to color to UgPasteBelow or fallback to default
----@field paste_above_hl? string If not "UgPasteAbove" then copy the to color to UgPasteAbove or fallback to default
----@field search_next_hl? string If not "UgSearchNext" then copy the to color to UgSearchNext or fallback to default
----@field search_prev_hl? string If not "UgSearchPrev" then copy the to color to UgSearchPrev or fallback to default
----@field undo_hl_color? UndoGlow.HlColor
----@field redo_hl_color? UndoGlow.HlColor
----@field yank_hl_color? UndoGlow.HlColor
----@field paste_below_hl_color? UndoGlow.HlColor
----@field paste_above_hl_color? UndoGlow.HlColor
----@field search_next_hl_color? UndoGlow.HlColor
----@field search_prev_hl_color? UndoGlow.HlColor
+---@field highlights? table<"undo" | "redo" | "yank" | "paste_below" | "paste_above" | "search_next" | "search_prev", { hl: string, hl_color: UndoGlow.HlColor }>
 
 ---@class UndoGlow.HlColor
 ---@field bg string
@@ -137,43 +124,38 @@ end
 
 ---@param user_config? UndoGlow.Config
 function M.setup(user_config)
-	M.config = vim.tbl_extend("force", M.config, user_config or {})
+	M.config = vim.tbl_deep_extend("force", M.config, user_config or {})
 
-	highlights.setup_highlight(
-		"UgUndo",
-		M.config.undo_hl,
-		M.config.undo_hl_color
-	)
-	highlights.setup_highlight(
-		"UgRedo",
-		M.config.redo_hl,
-		M.config.redo_hl_color
-	)
-	highlights.setup_highlight(
-		"UgYank",
-		M.config.yank_hl,
-		M.config.yank_hl_color
-	)
-	highlights.setup_highlight(
-		"UgPasteBelow",
-		M.config.paste_below_hl,
-		M.config.paste_below_hl_color
-	)
-	highlights.setup_highlight(
-		"UgPasteAbove",
-		M.config.paste_above_hl,
-		M.config.paste_above_hl_color
-	)
-	highlights.setup_highlight(
-		"UgSearchNext",
-		M.config.search_next_hl,
-		M.config.search_next_hl_color
-	)
-	highlights.setup_highlight(
-		"UgSearchPrev",
-		M.config.search_prev_hl,
-		M.config.search_prev_hl_color
-	)
+	local valid_keys = {
+		undo = true,
+		redo = true,
+		yank = true,
+		paste_below = true,
+		paste_above = true,
+		search_next = true,
+		search_prev = true,
+	}
+
+	for key in pairs(M.config.highlights) do
+		if not valid_keys[key] then
+			M.config.highlights[key] = nil
+		end
+	end
+
+	local target_map = {
+		undo = "UgUndo",
+		redo = "UgRedo",
+		yank = "UgYank",
+		paste_below = "UgPasteBelow",
+		paste_above = "UgPasteAbove",
+		search_next = "UgSearchNext",
+		search_prev = "UgSearchPrev",
+	}
+
+	for key, highlight in pairs(M.config.highlights) do
+		local target = target_map[key]
+		highlights.setup_highlight(target, highlight.hl, highlight.hl_color)
+	end
 end
 
 return M


### PR DESCRIPTION
While adding more built-in actions with different hlgroup, instead of
listing out all of the options in config, I think moving into a table is
a better choice. Please read the docs on how to set it up.

No errors will be thrown if you're using old config. The colors will
just fall back to default until you change them.
