### PR TITLE
feat!: move cmd out from attach function

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,36 +80,36 @@ Here is the default configuration:
  animation_type = "fade", -- default to "fade"
  fps = 120, -- change the fps, normally either 60 / 120
  easing = M.easing.ease_in_out_cubic, -- see more at easing section on how to change and create your own
-highlights = { -- Any keys other than these defaults will be ignored and omitted
- undo = {
-  hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
-  hl_color = { bg = "#FF5555" }, -- Ugly red color
+ highlights = { -- Any keys other than these defaults will be ignored and omitted
+  undo = {
+   hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
+   hl_color = { bg = "#FF5555" }, -- Ugly red color
+  },
+  redo = {
+   hl = "UgRedo", -- Same as above
+   hl_color = { bg = "#50FA7B" }, -- Ugly green color
+  },
+  yank = {
+   hl = "UgYank", -- Same as above
+   hl_color = { bg = "#F1FA8C" }, -- Ugly yellow color
+  },
+  paste_below = {
+   hl = "UgPasteBelow", -- Same as above
+   hl_color = { bg = "#8BE9FD" }, -- Ugly cyan color
+  },
+  paste_above = {
+   hl = "UgPasteAbove", -- Same as above
+   hl_color = { bg = "#BD93F9" }, -- Ugly purple color
+  },
+  search_next = {
+   hl = "UgSearchNext", -- Same as above
+   hl_color = { bg = "#FFB86C" }, -- Ugly orange color
+  },
+  search_prev = {
+   hl = "UgSearchPrev", -- Same as above
+   hl_color = { bg = "#FF79C6" }, -- Ugly pink color
+  },
  },
- redo = {
-  hl = "UgRedo", -- Same as above
-  hl_color = { bg = "#50FA7B" }, -- Ugly green color
- },
- yank = {
-  hl = "UgYank", -- Same as above
-  hl_color = { bg = "#F1FA8C" }, -- Ugly yellow color
- },
- paste_below = {
-  hl = "UgPasteBelow", -- Same as above
-  hl_color = { bg = "#8BE9FD" }, -- Ugly cyan color
- },
- paste_above = {
-  hl = "UgPasteAbove", -- Same as above
-  hl_color = { bg = "#BD93F9" }, -- Ugly purple color
- },
- search_next = {
-  hl = "UgSearchNext", -- Same as above
-  hl_color = { bg = "#FFB86C" }, -- Ugly orange color
- },
- search_prev = {
-  hl = "UgSearchPrev", -- Same as above
-  hl_color = { bg = "#FF79C6" }, -- Ugly pink color
- },
-},
 }
 ```
 
@@ -168,13 +168,12 @@ require("undo-glow").search_next() -- Search next command with highlights
 
 require("undo-glow").search_prev() -- Search prev command with highlights
 
----@class UndoGlow.AttachAndRunOpts
+---@class UndoGlow.HighlightChanges
 ---@field hlgroup string
----@field cmd? function
 ---@field animation_type? AnimationType -- Overwrites animation_type from config
 
----@param opts UndoGlow.AttachAndRunOpts
-require("undo-glow").attach_and_run(opts) -- API to create custom actions that highlights
+---@param opts UndoGlow.HighlightChanges
+require("undo-glow").highlight_changes(opts) -- API to highlight text changes
 
 ---@class UndoGlow.HighlightRegion
 ---@field hlgroup string
@@ -204,28 +203,68 @@ vim.api.nvim_create_autocmd("TextYankPost", {
 })
 ```
 
-### Creating custom command to highlight
+### Creating custom command to highlight changes
+
+E.g. undo, redo, etc
 
 ```lua
 function some_action()
- require("undo-glow").attach_and_run({
+ require("undo-glow").highlight_changes({
   hlgroup = "hlgroup",
-  cmd = function()
-   do_something_here()
-  end
+ })
+ do_something_here() -- some action that will cause text changes
+end
+
+--- then you can use it to bind to anywhere just like before. Undo and redo command are fundamentally doing the same thing.
+vim.keymap.set("n", "key_that_you_like", some_action, { silent = true })
+
+--- Example of undo function
+function undo()
+ require("undo-glow").highlight_changes({
+  hlgroup = "UgUndo",
+ })
+ vim.cmd("undo")
+end
+````
+
+Feel free to send a PR if you think there are some good actions that can be merged into the source.
+
+### Creating custom command that highlights without text changes
+
+E.g. search next, search previous, yank, etc
+
+```lua
+function some_action()
+ -- Do some calculation here and get the region coordinates that you want to highlight as below
+ -- s_row integer
+ -- s_col integer
+ -- e_row integer
+ -- e_col integer
+ local region = get_region()
+
+ -- And then pass those coordinates to the highlight_region function
+ require("undo-glow").highlight_region({
+  hlgroup = "hlgroup",
+  s_row = region.s_row,
+  s_col = region.s_col,
+  e_row = region.e_row,
+  e_col = region.e_col,
  })
 end
 
 --- then you can use it to bind to anywhere just like before. Undo and redo command are fundamentally doing the same thing.
-vim.keymap.set("n", "key_that_you_like", some_action, { noremap = true, silent = true })
+vim.keymap.set("n", "key_that_you_like", some_action, { silent = true })
 
---- Example of undo function
-function undo()
- require("undo-glow").attach_and_run({
-  hlgroup = "UgUndo",
-  cmd = function()
-   vim.cmd("undo")
-  end,
+--- Example of yank function
+function yank()
+ local pos = vim.fn.getpos("'[")
+ local pos2 = vim.fn.getpos("']")
+ require("undo-glow").highlight_region({
+  hlgroup = "UgYank",
+  s_row = pos[2] - 1,
+  s_col = pos[3] - 1,
+  e_row = pos2[2] - 1,
+  e_col = pos2[3],
  })
 end
 ````
@@ -233,6 +272,8 @@ end
 Feel free to send a PR if you think there are some good actions that can be merged into the source.
 
 ### Creating an autocmd that will highlight anything when textChanged
+
+I personally don't use autocmd for `TextChanged`. Use at your own risk!
 
 ```lua
 -- Also add `BufReadPost` so that it will also highlight for first changes

--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -116,36 +116,36 @@ Here is the default configuration:
      animation_type = "fade", -- default to "fade"
      fps = 120, -- change the fps, normally either 60 / 120
      easing = M.easing.ease_in_out_cubic, -- see more at easing section on how to change and create your own
-    highlights = { -- Any keys other than these defaults will be ignored and omitted
-     undo = {
-      hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
-      hl_color = { bg = "#FF5555" }, -- Ugly red color
+     highlights = { -- Any keys other than these defaults will be ignored and omitted
+      undo = {
+       hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
+       hl_color = { bg = "#FF5555" }, -- Ugly red color
+      },
+      redo = {
+       hl = "UgRedo", -- Same as above
+       hl_color = { bg = "#50FA7B" }, -- Ugly green color
+      },
+      yank = {
+       hl = "UgYank", -- Same as above
+       hl_color = { bg = "#F1FA8C" }, -- Ugly yellow color
+      },
+      paste_below = {
+       hl = "UgPasteBelow", -- Same as above
+       hl_color = { bg = "#8BE9FD" }, -- Ugly cyan color
+      },
+      paste_above = {
+       hl = "UgPasteAbove", -- Same as above
+       hl_color = { bg = "#BD93F9" }, -- Ugly purple color
+      },
+      search_next = {
+       hl = "UgSearchNext", -- Same as above
+       hl_color = { bg = "#FFB86C" }, -- Ugly orange color
+      },
+      search_prev = {
+       hl = "UgSearchPrev", -- Same as above
+       hl_color = { bg = "#FF79C6" }, -- Ugly pink color
+      },
      },
-     redo = {
-      hl = "UgRedo", -- Same as above
-      hl_color = { bg = "#50FA7B" }, -- Ugly green color
-     },
-     yank = {
-      hl = "UgYank", -- Same as above
-      hl_color = { bg = "#F1FA8C" }, -- Ugly yellow color
-     },
-     paste_below = {
-      hl = "UgPasteBelow", -- Same as above
-      hl_color = { bg = "#8BE9FD" }, -- Ugly cyan color
-     },
-     paste_above = {
-      hl = "UgPasteAbove", -- Same as above
-      hl_color = { bg = "#BD93F9" }, -- Ugly purple color
-     },
-     search_next = {
-      hl = "UgSearchNext", -- Same as above
-      hl_color = { bg = "#FFB86C" }, -- Ugly orange color
-     },
-     search_prev = {
-      hl = "UgSearchPrev", -- Same as above
-      hl_color = { bg = "#FF79C6" }, -- Ugly pink color
-     },
-    },
     }
 <
 
@@ -209,13 +209,12 @@ API                                        *undo-glow.nvim-undo-glow.nvim-api*
     
     require("undo-glow").search_prev() -- Search prev command with highlights
     
-    ---@class UndoGlow.AttachAndRunOpts
+    ---@class UndoGlow.HighlightChanges
     ---@field hlgroup string
-    ---@field cmd? function
     ---@field animation_type? AnimationType -- Overwrites animation_type from config
     
-    ---@param opts UndoGlow.AttachAndRunOpts
-    require("undo-glow").attach_and_run(opts) -- API to create custom actions that highlights
+    ---@param opts UndoGlow.HighlightChanges
+    require("undo-glow").highlight_changes(opts) -- API to highlight text changes
     
     ---@class UndoGlow.HighlightRegion
     ---@field hlgroup string
@@ -247,28 +246,70 @@ example:
 <
 
 
-CREATING CUSTOM COMMAND TO HIGHLIGHT ~
+CREATING CUSTOM COMMAND TO HIGHLIGHT CHANGES ~
+
+E.g. undo, redo, etc
 
 >lua
     function some_action()
-     require("undo-glow").attach_and_run({
+     require("undo-glow").highlight_changes({
       hlgroup = "hlgroup",
-      cmd = function()
-       do_something_here()
-      end
+     })
+     do_something_here() -- some action that will cause text changes
+    end
+    
+    --- then you can use it to bind to anywhere just like before. Undo and redo command are fundamentally doing the same thing.
+    vim.keymap.set("n", "key_that_you_like", some_action, { silent = true })
+    
+    --- Example of undo function
+    function undo()
+     require("undo-glow").highlight_changes({
+      hlgroup = "UgUndo",
+     })
+     vim.cmd("undo")
+    end
+<
+
+Feel free to send a PR if you think there are some good actions that can be
+merged into the source.
+
+
+CREATING CUSTOM COMMAND THAT HIGHLIGHTS WITHOUT TEXT CHANGES ~
+
+E.g. search next, search previous, yank, etc
+
+>lua
+    function some_action()
+     -- Do some calculation here and get the region coordinates that you want to highlight as below
+     -- s_row integer
+     -- s_col integer
+     -- e_row integer
+     -- e_col integer
+     local region = get_region()
+    
+     -- And then pass those coordinates to the highlight_region function
+     require("undo-glow").highlight_region({
+      hlgroup = "hlgroup",
+      s_row = region.s_row,
+      s_col = region.s_col,
+      e_row = region.e_row,
+      e_col = region.e_col,
      })
     end
     
     --- then you can use it to bind to anywhere just like before. Undo and redo command are fundamentally doing the same thing.
-    vim.keymap.set("n", "key_that_you_like", some_action, { noremap = true, silent = true })
+    vim.keymap.set("n", "key_that_you_like", some_action, { silent = true })
     
-    --- Example of undo function
-    function undo()
-     require("undo-glow").attach_and_run({
-      hlgroup = "UgUndo",
-      cmd = function()
-       vim.cmd("undo")
-      end,
+    --- Example of yank function
+    function yank()
+     local pos = vim.fn.getpos("'[")
+     local pos2 = vim.fn.getpos("']")
+     require("undo-glow").highlight_region({
+      hlgroup = "UgYank",
+      s_row = pos[2] - 1,
+      s_col = pos[3] - 1,
+      e_row = pos2[2] - 1,
+      e_col = pos2[3],
      })
     end
 <
@@ -278,6 +319,8 @@ merged into the source.
 
 
 CREATING AN AUTOCMD THAT WILL HIGHLIGHT ANYTHING WHEN TEXTCHANGED ~
+
+I personally don’t use autocmd for `TextChanged`. Use at your own risk!
 
 >lua
     -- Also add `BufReadPost` so that it will also highlight for first changes

--- a/lua/undo-glow/commands.lua
+++ b/lua/undo-glow/commands.lua
@@ -1,21 +1,17 @@
 local M = {}
 
 function M.undo()
-	require("undo-glow").attach_and_run({
+	require("undo-glow").highlight_changes({
 		hlgroup = "UgUndo",
-		cmd = function()
-			vim.cmd("undo")
-		end,
 	})
+	vim.cmd("undo")
 end
 
 function M.redo()
-	require("undo-glow").attach_and_run({
+	require("undo-glow").highlight_changes({
 		hlgroup = "UgRedo",
-		cmd = function()
-			vim.cmd("redo")
-		end,
 	})
+	vim.cmd("redo")
 end
 
 --- Helper to use this in autocmds. Do not use this as a command, it does nothing.
@@ -32,21 +28,17 @@ function M.yank()
 end
 
 function M.paste_below()
-	require("undo-glow").attach_and_run({
+	require("undo-glow").highlight_changes({
 		hlgroup = "UgPasteBelow",
-		cmd = function()
-			vim.cmd("normal! p")
-		end,
 	})
+	vim.cmd("normal! p")
 end
 
 function M.paste_above()
-	require("undo-glow").attach_and_run({
+	require("undo-glow").highlight_changes({
 		hlgroup = "UgPasteAbove",
-		cmd = function()
-			vim.cmd("normal! P")
-		end,
 	})
+	vim.cmd("normal! P")
 end
 
 function M.search_next()

--- a/lua/undo-glow/init.lua
+++ b/lua/undo-glow/init.lua
@@ -23,9 +23,8 @@ local M = {}
 ---@field g integer Green (0-255)
 ---@field b integer Blue (0-255)
 
----@class UndoGlow.AttachAndRunOpts
+---@class UndoGlow.HighlightChanges
 ---@field hlgroup string
----@field cmd? function
 ---@field animation_type? AnimationType
 
 ---@class UndoGlow.HighlightRegion: UndoGlow.RowCol
@@ -70,8 +69,8 @@ local callback = require("undo-glow.callback")
 local utils = require("undo-glow.utils")
 
 -- Helper to attach to a buffer with a local state.
----@param opts UndoGlow.AttachAndRunOpts
-function M.attach_and_run(opts)
+---@param opts UndoGlow.HighlightChanges
+function M.highlight_changes(opts)
 	local bufnr = vim.api.nvim_get_current_buf()
 
 	---@type UndoGlow.State
@@ -86,10 +85,6 @@ function M.attach_and_run(opts)
 			return callback.on_bytes_wrapper(state, M.config, ...)
 		end,
 	})
-
-	if opts.cmd then
-		opts.cmd()
-	end
 end
 
 --- Highlight a specified region in the current buffer.


### PR DESCRIPTION
Apperently running commands outside of the attach function is more
reliable. Since this changes, I decided to rename the API to
`highlight_changes` instead of `attach_and_run`, which is more
appropriate consider what it does now.
