### PR TITLE
fix: follow linked hlgroups instead of ignore

### DIFF
--- a/lua/undo-glow/highlight.lua
+++ b/lua/undo-glow/highlight.lua
@@ -42,4 +42,23 @@ function M.setup_highlight(target_hlgroup, config_hl, config_hl_color)
 	end
 end
 
+---@param hlgroup string
+---@return vim.api.keyset.hl_info
+function M.resolve_hlgroup(hlgroup)
+	local seen = {}
+	while hlgroup do
+		if seen[hlgroup] then
+			break
+		end
+		seen[hlgroup] = true
+
+		local hl = vim.api.nvim_get_hl(0, { name = hlgroup })
+		if not hl.link then
+			return hl
+		end
+		hlgroup = hl.link
+	end
+	return {}
+end
+
 return M

--- a/lua/undo-glow/utils.lua
+++ b/lua/undo-glow/utils.lua
@@ -5,6 +5,7 @@ local counter = 0 -- For unique highlight groups
 M.ns = vim.api.nvim_create_namespace("undo-glow")
 
 local color = require("undo-glow.color")
+local highlight = require("undo-glow.highlight")
 
 ---@param base string
 ---@return string
@@ -103,8 +104,10 @@ function M.handle_highlight(opts)
 				and M.get_unique_hlgroup(opts.state.current_hlgroup)
 			or opts.state.current_hlgroup
 
+		-- TODO: Think of any other way that don't need to follow links or faster
+		-- Follow links if exists and get the actual color code for bg and fg
 		local current_hlgroup_detail =
-			vim.api.nvim_get_hl(0, { name = opts.state.current_hlgroup })
+			highlight.resolve_hlgroup(opts.state.current_hlgroup)
 
 		local bg = nil
 		local fg = nil


### PR DESCRIPTION
This fix will allow users to set the hlgroups outside of the plugin.
E.g. `Snacks.util.set_hl({ UgYank = "Cursor" }, { default = true })`, it
should still work and grabbing the right colors after this change.
