### PR TITLE
feat!: move animation related opts to animation key

### DIFF
--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -619,11 +619,16 @@ ANIMATIONS & EASINGS      *undo-glow.nvim-undo-glow.nvim-animations-&-easings*
 
 ANIMATIONS ~
 
-**undo-glow.nvim** comes with 4 default animations out of the box and can be
-toggled on and off and swap globally or per action (incuding your custom one).
-If you wish to, every different action can have different animation
-configurations.
 
+  [!note] Animation is `off` by default. You can turn it on in your config with
+  `animation.enabled = true`.
+**undo-glow.nvim** comes with 4 default animations out of the box and can be
+toggled on and off and swap globally or per action (incuding your custom
+actions).
+
+
+  [!note] If you wish to, every different action can have different animation
+  configurations.
 >lua
     ---@alias AnimationType "fade" | "blink" | "pulse" | "jitter"
 <
@@ -683,6 +688,9 @@ free to send PRs for more interesting easings.
   [!note] Not all animation supports easing. Only `pulse` and `fade (default)`
   supports easing. If you use other animation and set easing, it will just get
   ignored.
+
+  [!warning] Easing wil be ignored if `animation.enabled` is `off`. Make sure you
+  turn it on if you want easing.
 
 BUILTIN EASINGS
 

--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -122,12 +122,15 @@ DEFAULT OPTIONS ~
     ---@alias AnimationType "fade" | "blink" | "pulse" | "jitter"
     
     ---@class UndoGlow.Config
+    ---@field animation? UndoGlow.Config.Animation
+    ---@field highlights? table<"undo" | "redo" | "yank" | "paste" | "search" | "comment", { hl: string, hl_color: UndoGlow.HlColor }>
+    
+    ---@class UndoGlow.Config.Animation
+    ---@field enabled? boolean Turn on or off for animation
     ---@field duration? number Highlight duration in ms
-    ---@field animation? boolean Turn on or off for animation
     ---@field animation_type? AnimationType
     ---@field easing? fun(opts: UndoGlow.EasingOpts): integer A function that computes easing.
     ---@field fps? number Normally either 60 / 120, up to you
-    ---@field highlights? table<"undo" | "redo" | "yank" | "paste" | "search" | "comment", { hl: string, hl_color: UndoGlow.HlColor }>
     
     ---@class UndoGlow.EasingOpts
     ---@field time integer Elapsed time
@@ -142,11 +145,13 @@ DEFAULT OPTIONS ~
     ---@field bg string Background color
     ---@field fg? string Optional for text color (Without this, it will just remain the existing text color as it is)
     {
-     duration = 500, -- in ms
-     animation = true, -- whether to turn on or off for animation
-     animation_type = "fade", -- default to "fade"
-     fps = 120, -- change the fps, normally either 60 / 120, but it can be whatever number
-     easing = require("undo-glow").easing.in_out_cubic, -- see more at easing section on how to change and create your own
+     animation = {
+      animation = false, -- whether to turn on or off for animation
+      duration = 100, -- in ms
+      animation_type = "fade", -- default to "fade"
+      fps = 120, -- change the fps, normally either 60 / 120, but it can be whatever number
+      easing = require("undo-glow").easing.in_out_cubic, -- see more at easing section on how to change and create your own
+     },
      highlights = { -- Any keys other than these defaults will be ignored and omitted
       undo = {
        hl = "UgUndo", -- This will not set new hlgroup, if it's not "UgUndo", we will try to grab the colors of specified hlgroup and apply to "UgUndo"
@@ -186,6 +191,10 @@ My setup in my config ~
       event = { "VeryLazy" },
       ---@type UndoGlow.Config
       opts = {
+       animation = {
+        enabled = true,
+        duration = 500,
+       },
        highlights = {
         undo = {
          hl_color = { bg = "#48384B" },
@@ -342,6 +351,9 @@ Each builtin commands takes in optional `opts` take allows to configure
 >lua
     ---@class UndoGlow.CommandOpts
     ---@field hlgroup? string
+    ---@field animation? UndoGlow.Config.Animation
+    
+    ---@class UndoGlow.Config.Animation
     ---@field duration? number Highlight duration in ms
     ---@field animation? boolean Turn on or off for animation
     ---@field animation_type? AnimationType
@@ -461,8 +473,11 @@ HIGHLIGHT TEXT CHANGES
 >lua
     ---@class UndoGlow.HighlightChanges
     ---@field hlgroup? string -- Default to `UgUndo`
+    ---@field animation? UndoGlow.Config.Animation
+    
+    ---@class UndoGlow.Config.Animation
+    ---@field enabled? boolean Turn on or off for animation
     ---@field duration? number Highlight duration in ms
-    ---@field animation? boolean Turn on or off for animation
     ---@field animation_type? AnimationType
     ---@field easing? fun(opts: UndoGlow.EasingOpts): integer A function that computes easing.
     ---@field fps? number Normally either 60 / 120, up to you
@@ -503,15 +518,18 @@ HIGHLIGHT ANY REGION OF YOUR CHOICE
 >lua
     ---@class UndoGlow.HighlightRegion
     ---@field hlgroup? string
-    ---@field duration? number Highlight duration in ms
-    ---@field animation? boolean Turn on or off for animation
-    ---@field animation_type? AnimationType
-    ---@field easing? fun(opts: UndoGlow.EasingOpts): integer A function that computes easing.
-    ---@field fps? number Normally either 60 / 120, up to you
+    ---@field animation? UndoGlow.Config.Animation
     ---@field s_row integer Start row
     ---@field s_col integer Start column
     ---@field e_row integer End row
     ---@field e_col integer End column
+    
+    ---@class UndoGlow.Config.Animation
+    ---@field enabled? boolean Turn on or off for animation
+    ---@field duration? number Highlight duration in ms
+    ---@field animation_type? AnimationType
+    ---@field easing? fun(opts: UndoGlow.EasingOpts): integer A function that computes easing.
+    ---@field fps? number Normally either 60 / 120, up to you
     
     --- @param opts UndoGlow.HighlightRegion Options for highlighting the region:
     require("undo-glow").highlight_region(opts) -- API to highlight certain region without text changes
@@ -729,6 +747,29 @@ CHANGING EASING FROM CONFIGURATION WITH BUILTIN
   `easing` functions from **undo-glow.nvim** at opts. If that’s the case, you
   can try to import them at the `config` key before calling the `setup` function.
   See below.
+
+METHOD 1: SET IT IN OPTS WITH FUNCTION
+
+>lua
+    {
+     "y3owk1n/undo-glow.nvim",
+     version = "*",
+     event = { "VeryLazy" },
+     ---@param _ any
+     ---@param opts UndoGlow.Config
+     opts = function(_, opts)
+      return {
+       animation = {
+        easing = require("undo-glow").easing.out_in_elastic,
+       },
+      }
+     end,
+    },
+<
+
+
+METHOD 2: SET IT IN CONFIG
+
 >lua
     {
      "y3owk1n/undo-glow.nvim",

--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -9,7 +9,7 @@ M.animate = {}
 ---@param animateFn function
 local function animate_wrapper(opts, animateFn)
 	local start_time = vim.uv.hrtime()
-	local interval = 1000 / opts.state.fps
+	local interval = 1000 / opts.state.animation.fps
 	local timer = vim.uv.new_timer()
 
 	if timer then
@@ -44,7 +44,7 @@ function M.animate.fade(opts)
 		local now = vim.uv.hrtime()
 		local elapsed = (now - start_time) / 1e6 -- convert from ns to ms
 		local t = math.min(elapsed / opts.duration, 1)
-		local eased = opts.state.easing({
+		local eased = opts.state.animation.easing({
 			time = t,
 			begin = 0,
 			change = 1,
@@ -174,7 +174,7 @@ function M.animate.pulse(opts)
 		local now = vim.uv.hrtime()
 		local elapsed = (now - start_time) / 1e6 -- convert ns to ms
 		local t = 0.5 * (1 - math.cos(2 * math.pi * (elapsed / opts.duration)))
-		local eased = opts.state.easing({
+		local eased = opts.state.animation.easing({
 			time = t,
 			begin = 0,
 			change = 1,

--- a/lua/undo-glow/config.lua
+++ b/lua/undo-glow/config.lua
@@ -1,10 +1,12 @@
 ---@type UndoGlow.Config
 local config = {
-	duration = 500,
-	animation = true,
-	animation_type = "fade",
-	easing = require("undo-glow.easing").in_out_cubic,
-	fps = 120,
+	animation = {
+		enabled = false,
+		duration = 100,
+		animation_type = "fade",
+		fps = 120,
+		easing = require("undo-glow.easing").in_out_cubic,
+	},
 	highlights = {
 		undo = {
 			hl = "UgUndo",

--- a/lua/undo-glow/init.lua
+++ b/lua/undo-glow/init.lua
@@ -1,7 +1,8 @@
 local M = {}
 ---@alias AnimationType "fade" | "blink" | "pulse" | "jitter"
 
----@class UndoGlow.Config : UndoFlow.Config.Animation
+---@class UndoGlow.Config
+---@field animation? UndoGlow.Config.Animation
 ---@field highlights? table<"undo" | "redo" | "yank" | "paste" | "search" | "comment", { hl: string, hl_color: UndoGlow.HlColor }>
 
 ---@class UndoGlow.EasingOpts
@@ -13,9 +14,9 @@ local M = {}
 ---@field period? integer Period
 ---@field overshoot? integer Overshoot
 
----@class UndoFlow.Config.Animation
+---@class UndoGlow.Config.Animation
+---@field enabled? boolean Turn on or off for animation
 ---@field duration? number Highlight duration in ms
----@field animation? boolean Turn on or off for animation
 ---@field animation_type? AnimationType
 ---@field easing? fun(opts: UndoGlow.EasingOpts): integer A function that computes easing.
 ---@field fps? number Normally either 60 / 120, up to you
@@ -24,17 +25,19 @@ local M = {}
 ---@field bg string
 ---@field fg? string
 
----@class UndoGlow.State : UndoFlow.Config.Animation
+---@class UndoGlow.State
 ---@field current_hlgroup string
 ---@field should_detach boolean
+---@field animation? UndoGlow.Config.Animation
 
 ---@class UndoGlow.RGBColor
 ---@field r integer Red (0-255)
 ---@field g integer Green (0-255)
 ---@field b integer Blue (0-255)
 
----@class UndoGlow.CommandOpts : UndoFlow.Config.Animation
+---@class UndoGlow.CommandOpts
 ---@field hlgroup? string
+---@field animation? UndoGlow.Config.Animation
 
 ---@class UndoGlow.HighlightChanges : UndoGlow.CommandOpts
 


### PR DESCRIPTION
Since animation can be configured everywhere, it is easier and nicer to
set in it it's own table for more clarity. Furthermore animation is now
off by default. You need to explicitly turn it on globally or per action
basis.
