### PR TITLE
fix(utils.merge_command_opts): make sure opts are always table

### DIFF
--- a/lua/undo-glow/utils.lua
+++ b/lua/undo-glow/utils.lua
@@ -317,6 +317,8 @@ end
 ---@param opts? UndoGlow.CommandOpts Optional command options.
 ---@return UndoGlow.CommandOpts The merged command options.
 function M.merge_command_opts(hlgroup, opts)
+	opts = (type(opts) == "table") and opts or {}
+
 	opts = vim.tbl_extend("force", {
 		hlgroup = hlgroup,
 		animation = {
@@ -326,7 +328,7 @@ function M.merge_command_opts(hlgroup, opts)
 			easing = nil,
 			fps = nil,
 		},
-	}, opts or {})
+	}, opts)
 
 	return opts
 end

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -409,6 +409,33 @@ describe("undo-glow.utils", function()
 			assert.is_nil(result.animation.easing)
 			assert.is_nil(result.animation.fps)
 		end)
+		it(
+			"should merge command options with defaults if opts is empty table",
+			function()
+				local opts = {}
+				local result = utils.merge_command_opts("TestHL", opts)
+				assert.equals("TestHL", result.hlgroup)
+				assert.is_table(result.animation)
+				-- The merged animation table should have the keys forced to nil.
+				assert.is_nil(result.animation.enabled)
+				assert.is_nil(result.animation.animation_type)
+				assert.is_nil(result.animation.duration)
+				assert.is_nil(result.animation.easing)
+				assert.is_nil(result.animation.fps)
+			end
+		)
+		it("should merge command options with defaults if opts is 0", function()
+			local opts = 0
+			local result = utils.merge_command_opts("TestHL", opts)
+			assert.equals("TestHL", result.hlgroup)
+			assert.is_table(result.animation)
+			-- The merged animation table should have the keys forced to nil.
+			assert.is_nil(result.animation.enabled)
+			assert.is_nil(result.animation.animation_type)
+			assert.is_nil(result.animation.duration)
+			assert.is_nil(result.animation.easing)
+			assert.is_nil(result.animation.fps)
+		end)
 	end)
 
 	describe("create_state", function()


### PR DESCRIPTION
This should fix the error when `_` is interpreted as 0 instead of {} or
nil when using the function, since opts is optional.
