### PR TITLE
feat: add ability to scope highlights to current window only

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ require("undo-glow").setup({
 ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
 ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
 ---@field fps? number Frames per second for the animation.
+---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
 
 ---Options passed to easing functions.
 ---@class UndoGlow.EasingOpts
@@ -152,6 +153,7 @@ require("undo-glow").setup({
   animation_type = "fade", -- default to "fade", see more at animation section on how to change or create your own
   fps = 120, -- change the fps, normally either 60 / 120, but it can be whatever number
   easing = "in_out_cubic", -- see more at easing section on how to change and create your own
+  window_scoped = false, -- this uses an experimental extmark options (it might not work depends on your version of neovim)
  },
  highlights = { -- Any keys other than these defaults will be ignored and omitted
   undo = {
@@ -204,6 +206,7 @@ See the example below for how to configure **undo-glow.nvim**.
    enabled = true,
    duration = 300,
    animtion_type = "zoom",
+   window_scoped = true,
   },
   highlights = {
    undo = {
@@ -400,6 +403,7 @@ Each builtin commands takes in optional `opts` take allows to configure **color*
 ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
 ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
 ---@field fps? number Frames per second for the animation.
+---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
 ```
 
 #### Undo Highlights
@@ -659,6 +663,7 @@ vim.api.nvim_create_autocmd("CursorMoved", {
 ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
 ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
 ---@field fps? number Frames per second for the animation.
+---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
 
 ---Core API to highlight changes in the current buffer.
 ---@param opts? UndoGlow.HighlightChanges|UndoGlow.CommandOpts
@@ -719,6 +724,7 @@ end
 ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
 ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
 ---@field fps? number Frames per second for the animation.
+---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
 
 ---Core API to highlight a specified region in the current buffer.
 ---@param opts UndoGlow.HighlightRegion
@@ -1019,6 +1025,7 @@ Moves the highlight horizontally to the right across the text before fading out.
 ---Parameters for an animation.
 ---@class UndoGlow.Animation
 ---@field bufnr integer Buffer number.
+---@field ns integer Namespace id.
 ---@field hlgroup string Highlight group name.
 ---@field extmark_ids? integer[] Extmark identifiers.
 ---@field start_bg UndoGlow.RGBColor Starting background color.
@@ -1094,11 +1101,12 @@ Moves the highlight horizontally to the right across the text before fading out.
      e_col = opts.coordinates.e_col,
      priority = opts.config.priority,
      force_edge = opts.state.force_edge,
+     window_scoped = opts.state.animation.window_scoped,
     })
 
    local extmark_id = vim.api.nvim_buf_set_extmark(
     opts.bufnr,
-    require("undo-glow.utils").ns,
+    opts.ns,
     opts.coordinates.s_row,
     opts.coordinates.s_col,
     extmark_opts

--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -129,6 +129,7 @@ DEFAULT OPTIONS ~
     ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
     ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
     ---@field fps? number Frames per second for the animation.
+    ---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
     
     ---Options passed to easing functions.
     ---@class UndoGlow.EasingOpts
@@ -152,6 +153,7 @@ DEFAULT OPTIONS ~
       animation_type = "fade", -- default to "fade", see more at animation section on how to change or create your own
       fps = 120, -- change the fps, normally either 60 / 120, but it can be whatever number
       easing = "in_out_cubic", -- see more at easing section on how to change and create your own
+      window_scoped = false, -- this uses an experimental extmark options (it might not work depends on your version of neovim)
      },
      highlights = { -- Any keys other than these defaults will be ignored and omitted
       undo = {
@@ -204,6 +206,7 @@ See the example below for how to configure **undo-glow.nvim**.
        enabled = true,
        duration = 300,
        animtion_type = "zoom",
+       window_scoped = true,
       },
       highlights = {
        undo = {
@@ -404,6 +407,7 @@ Each builtin commands takes in optional `opts` take allows to configure
     ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
     ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
     ---@field fps? number Frames per second for the animation.
+    ---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
 <
 
 
@@ -632,6 +636,7 @@ HIGHLIGHT TEXT CHANGES
     ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
     ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
     ---@field fps? number Frames per second for the animation.
+    ---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
     
     ---Core API to highlight changes in the current buffer.
     ---@param opts? UndoGlow.HighlightChanges|UndoGlow.CommandOpts
@@ -688,6 +693,7 @@ HIGHLIGHT ANY REGION OF YOUR CHOICE
     ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
     ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
     ---@field fps? number Frames per second for the animation.
+    ---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
     
     ---Core API to highlight a specified region in the current buffer.
     ---@param opts UndoGlow.HighlightRegion
@@ -916,6 +922,7 @@ ANIMATION TYPE IN FUNCTION
     ---Parameters for an animation.
     ---@class UndoGlow.Animation
     ---@field bufnr integer Buffer number.
+    ---@field ns integer Namespace id.
     ---@field hlgroup string Highlight group name.
     ---@field extmark_ids? integer[] Extmark identifiers.
     ---@field start_bg UndoGlow.RGBColor Starting background color.
@@ -992,11 +999,12 @@ EXAMPLE USING BLINK ANIMATION FROM SOURCE CODE
          e_col = opts.coordinates.e_col,
          priority = opts.config.priority,
          force_edge = opts.state.force_edge,
+         window_scoped = opts.state.animation.window_scoped,
         })
     
        local extmark_id = vim.api.nvim_buf_set_extmark(
         opts.bufnr,
-        require("undo-glow.utils").ns,
+        opts.ns,
         opts.coordinates.s_row,
         opts.coordinates.s_col,
         extmark_opts

--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -22,11 +22,7 @@ function M.animate_clear(opts, timer)
 		end
 
 		for _, id in ipairs(ids) do
-			vim.api.nvim_buf_del_extmark(
-				opts.bufnr,
-				require("undo-glow.utils").ns,
-				id
-			)
+			vim.api.nvim_buf_del_extmark(opts.bufnr, opts.ns, id)
 		end
 	end
 	vim.cmd("hi clear " .. opts.hlgroup)
@@ -95,11 +91,12 @@ function M.animate.fade(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -145,11 +142,12 @@ function M.animate.fade_reverse(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -194,11 +192,12 @@ function M.animate.blink(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -242,11 +241,12 @@ function M.animate.jitter(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -291,11 +291,12 @@ function M.animate.pulse(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -347,11 +348,12 @@ function M.animate.spring(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -395,11 +397,12 @@ function M.animate.desaturate(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -438,11 +441,12 @@ function M.animate.strobe(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -483,11 +487,12 @@ function M.animate.zoom(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -530,11 +535,12 @@ function M.animate.rainbow(opts)
 		e_col = opts.coordinates.e_col,
 		priority = opts.config.priority,
 		force_edge = opts.state.force_edge,
+		window_scoped = opts.state.animation.window_scoped,
 	})
 
 	local extmark_id = vim.api.nvim_buf_set_extmark(
 		opts.bufnr,
-		require("undo-glow.utils").ns,
+		opts.ns,
 		opts.coordinates.s_row,
 		opts.coordinates.s_col,
 		extmark_opts
@@ -559,7 +565,7 @@ end
 ---@return boolean|nil status Return `false` to fallback to fade
 function M.animate.slide(opts)
 	local buf = opts.bufnr
-	local ns = require("undo-glow.utils").ns
+	local ns = opts.ns
 
 	local is_multiline_with_zero_start_end = opts.coordinates.e_row
 			> opts.coordinates.s_row
@@ -593,6 +599,7 @@ function M.animate.slide(opts)
 			e_col = opts.coordinates.e_col,
 			priority = opts.config.priority,
 			force_edge = opts.state.force_edge,
+			window_scoped = opts.state.animation.window_scoped,
 		})
 
 		local extmark_id = vim.api.nvim_buf_set_extmark(
@@ -724,6 +731,7 @@ function M.animate.slide(opts)
 					e_col = e_col,
 					priority = opts.config.priority,
 					force_edge = opts.state.force_edge,
+					window_scoped = opts.state.animation.window_scoped,
 				})
 			local id =
 				vim.api.nvim_buf_set_extmark(buf, ns, row, s_col, extmark_opts)

--- a/lua/undo-glow/config.lua
+++ b/lua/undo-glow/config.lua
@@ -6,6 +6,7 @@ local config = {
 		animation_type = "fade",
 		fps = 120,
 		easing = "in_out_cubic",
+		window_scoped = false,
 	},
 	highlights = {
 		undo = {

--- a/lua/undo-glow/health.lua
+++ b/lua/undo-glow/health.lua
@@ -67,6 +67,29 @@ function M.check()
 		report_status("ok", "nvim_set_hl API is available.")
 	end
 
+	-- Check if `scoped` is available for extmark
+	local dummy_buf = vim.api.nvim_create_buf(false, true)
+	local test_ns = vim.api.nvim_create_namespace("HealthExtmarkTest")
+	local ok, err = pcall(function()
+		vim.api.nvim_buf_set_extmark(dummy_buf, test_ns, 0, 0, {
+			virt_text = { { "test", "None" } },
+			scoped = true,
+		})
+	end)
+	if ok then
+		report_status(
+			"ok",
+			"vim.api.nvim_buf_set_extmark supports the 'scoped' option (experimental)."
+		)
+	else
+		report_status(
+			"warn",
+			"vim.api.nvim_buf_set_extmark does not support the 'scoped' option: "
+				.. err
+		)
+	end
+	vim.api.nvim_buf_delete(dummy_buf, { force = true })
+
 	separator("Module Load Checks")
 	-- Check that required plugin modules load successfully.
 	local required_modules = {

--- a/lua/undo-glow/types.lua
+++ b/lua/undo-glow/types.lua
@@ -29,6 +29,7 @@
 ---@field animation_type? UndoGlow.AnimationTypeString|UndoGlow.AnimationTypeFn Animation type (a string key or a custom function).
 ---@field easing? UndoGlow.EasingString|UndoGlow.EasingFn Easing function (a string key or a custom function).
 ---@field fps? number Frames per second for the animation.
+---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.
 
 ---Highlight color information.
 ---@class UndoGlow.HlColor
@@ -69,6 +70,7 @@
 ---Parameters for an animation.
 ---@class UndoGlow.Animation
 ---@field bufnr integer Buffer number.
+---@field ns integer Namespace id.
 ---@field hlgroup string Highlight group name.
 ---@field extmark_ids? integer[] Extmark identifiers.
 ---@field start_bg UndoGlow.RGBColor Starting background color.
@@ -83,6 +85,7 @@
 ---Handle for highlighting operations, including region coordinates.
 ---@class UndoGlow.HandleHighlight : UndoGlow.RowCol
 ---@field bufnr integer Buffer number.
+---@field ns integer Namespace id.
 ---@field config UndoGlow.Config Configuration for undo-glow.
 ---@field state UndoGlow.State Current state of the highlight.
 
@@ -99,3 +102,4 @@
 ---@field hlgroup string Highlight group name.
 ---@field priority integer Extmark priority to render the highlight (Default 4096).
 ---@field force_edge? boolean Whether to force edge highlighting.
+---@field window_scoped? boolean If enabled, the highlight effect is constrained to the current active window, even if the buffer is shared across splits.

--- a/tests/animation_spec.lua
+++ b/tests/animation_spec.lua
@@ -25,7 +25,8 @@ describe("undo-glow.animation", function()
 		it("should stop and close the timer", function()
 			local timer = uv.new_timer()
 			timer:start(1000, 1000, function() end)
-			local opts = { bufnr = bufnr, extmark_id = 1, hlgroup = hlgroup }
+			local opts =
+				{ bufnr = bufnr, ns = ns, extmark_id = 1, hlgroup = hlgroup }
 			animation.animate_clear(opts, timer)
 			assert.is_false(timer:is_active(), "Timer should be stopped")
 		end)
@@ -34,8 +35,12 @@ describe("undo-glow.animation", function()
 			local extmark_ids = {}
 			local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, ns, 0, 0, {})
 			table.insert(extmark_ids, extmark_id)
-			local opts =
-				{ bufnr = bufnr, extmark_ids = extmark_ids, hlgroup = hlgroup }
+			local opts = {
+				bufnr = bufnr,
+				ns = ns,
+				extmark_ids = extmark_ids,
+				hlgroup = hlgroup,
+			}
 			local timer = uv.new_timer()
 			animation.animate_clear(opts, timer)
 
@@ -56,8 +61,12 @@ describe("undo-glow.animation", function()
 				[3] = extmark_id3,
 			}
 
-			local opts =
-				{ bufnr = bufnr, extmark_ids = extmark_ids, hlgroup = hlgroup }
+			local opts = {
+				bufnr = bufnr,
+				ns = ns,
+				extmark_ids = extmark_ids,
+				hlgroup = hlgroup,
+			}
 			local timer = uv.new_timer()
 			animation.animate_clear(opts, timer)
 
@@ -86,6 +95,7 @@ describe("undo-glow.animation", function()
 
 				local opts = {
 					bufnr = bufnr,
+					ns = ns,
 					extmark_ids = extmark_ids,
 					hlgroup = hlgroup,
 				}
@@ -100,7 +110,7 @@ describe("undo-glow.animation", function()
 
 		it("should clear the highlight group", function()
 			vim.api.nvim_set_hl(0, hlgroup, { bg = "#FF0000" })
-			local opts = { hlgroup = hlgroup, bufnr = bufnr }
+			local opts = { hlgroup = hlgroup, ns = ns, bufnr = bufnr }
 			local timer = uv.new_timer()
 			animation.animate_clear(opts, timer)
 			local hl = vim.api.nvim_get_hl(0, { name = hlgroup })


### PR DESCRIPTION
This change will allow to scope highlights to only current window to
reduce noises. However, please note that this is utilising an
experimental extmark option `scoped`. Not sure if there will be any
regression considering different neovim version are out there...
