### PR TITLE
fix(types): make ns optional for handle_highlight function

### DIFF
--- a/lua/undo-glow/types.lua
+++ b/lua/undo-glow/types.lua
@@ -85,7 +85,7 @@
 ---Handle for highlighting operations, including region coordinates.
 ---@class UndoGlow.HandleHighlight : UndoGlow.RowCol
 ---@field bufnr integer Buffer number.
----@field ns integer Namespace id.
+---@field ns? integer Namespace id.
 ---@field config UndoGlow.Config Configuration for undo-glow.
 ---@field state UndoGlow.State Current state of the highlight.
 


### PR DESCRIPTION
This is not needed to pass from outer functions. The internal will
create the right ns as going.
