### PR TITLE
fix(utils.create_extmark_opts): different API for setting windown namespace for nightly and stable

### DIFF
--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -1,4 +1,4 @@
-*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 March 05
+*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 March 06
 
 ==============================================================================
 Table of Contents                           *undo-glow.nvim-table-of-contents*

--- a/lua/undo-glow/health.lua
+++ b/lua/undo-glow/health.lua
@@ -90,6 +90,38 @@ function M.check()
 	end
 	vim.api.nvim_buf_delete(dummy_buf, { force = true })
 
+	-- New health check for experimental namespace functions.
+	local dummy_win = vim.api.nvim_get_current_win()
+	local dummy_ns = vim.api.nvim_create_namespace("HealthNamespaceTest")
+	local function_string
+	local ok_ns, err_ns = pcall(function()
+		if vim.fn.has("nvim-0.11") == 1 then
+			-- Experimental API for nvim-0.11 and later.
+			vim.api.nvim__ns_set(dummy_ns, { wins = { dummy_win } })
+			function_string = "'vim.api.nvim__ns_set'"
+		else
+			-- Fallback for older versions.
+			vim.api.nvim__win_add_ns(dummy_win, dummy_ns)
+			function_string = "'vim.api.nvim__win_add_ns'"
+		end
+	end)
+	if ok_ns then
+		report_status(
+			"ok",
+			"Experimental namespace API "
+				.. function_string
+				.. " functions are callable."
+		)
+	else
+		report_status(
+			"error",
+			"Experimental namespace API "
+				.. function_string
+				.. " functions are not callable: "
+				.. err_ns
+		)
+	end
+
 	separator("Module Load Checks")
 	-- Check that required plugin modules load successfully.
 	local required_modules = {

--- a/lua/undo-glow/utils.lua
+++ b/lua/undo-glow/utils.lua
@@ -426,6 +426,7 @@ end
 ---@param opts UndoGlow.ExtmarkOpts
 ---@return vim.api.keyset.set_extmark extmark_opts
 function M.create_extmark_opts(opts)
+	---@type vim.api.keyset.set_extmark
 	local extmark_opts = {
 		end_row = opts.e_row,
 		end_col = opts.e_col,
@@ -486,10 +487,19 @@ function M.create_namespace(bufnr, window_scoped)
 			M.win_namespaces[current_win_id] = vim.api.nvim_create_namespace(
 				"undo-glow-win-" .. current_win_id
 			)
-			vim.api.nvim__win_add_ns(
-				current_win_id,
-				M.win_namespaces[current_win_id]
-			)
+
+			if vim.fn.has("nvim-0.11") == 1 then
+				-- NOTE: This is still an experimental API for nightly and might change in the future.
+				-- Specifically on `v0.11.0-dev-1912+g0c0352783f` when i fix this issue.
+				vim.api.nvim__ns_set(M.win_namespaces[current_win_id], {
+					wins = { current_win_id },
+				})
+			else
+				vim.api.nvim__win_add_ns(
+					current_win_id,
+					M.win_namespaces[current_win_id]
+				)
+			end
 		end
 
 		for win_id, _ in pairs(M.win_namespaces) do


### PR DESCRIPTION
Upon diving deep into the source, 0.11 doesn't
`vim.api.nvim__win_add_ns` anymore. I think `vim.api.nvim__ns_set` might
be the equivalent for it. Not so sure as nightly doesn't have good docs.
It's current working fine for nightly version
`v0.11.0-dev-1912+g0c0352783f`. Keep an eye on future nightly releases
as the API might be changing anytime soon or never.
