### PR TITLE
fix(animation.slide): add pcall for setting extmark

### DIFF
--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -680,7 +680,8 @@ function M.animate.slide(opts)
 				end
 			end
 
-			vim.api.nvim_buf_set_extmark(
+			pcall(
+				vim.api.nvim_buf_set_extmark,
 				buf,
 				ns,
 				original_row,
@@ -813,7 +814,8 @@ function M.animate.slide(opts)
 					end
 				end
 
-				vim.api.nvim_buf_set_extmark(
+				pcall(
+					vim.api.nvim_buf_set_extmark,
 					buf,
 					ns,
 					row,


### PR DESCRIPTION
This change might fix the weird error where when you copy and paste full
document text, it might throw `end_col` exceeded error. Maybe fixed it
but not sure, let's see.
