### PR TITLE
fix(animation.slide): fixes end_col out of range error in certain cases

### DIFF
--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -602,12 +602,6 @@ function M.animate.slide(opts)
 			window_scoped = opts.state.animation.window_scoped,
 		})
 
-		local line_count = vim.api.nvim_buf_line_count(opts.bufnr)
-
-		if line_count - 1 >= opts.coordinates.e_row then
-			return false
-		end
-
 		local created_extmark_status, created_extmark_result = pcall(
 			vim.api.nvim_buf_set_extmark,
 			buf,
@@ -645,8 +639,18 @@ function M.animate.slide(opts)
 				original_row + 1,
 				false
 			)
+
 			local line = (success_lines and lines[1] or "") or ""
 			local line_end = opts.coordinates.e_col
+
+			local line_count = vim.api.nvim_buf_line_count(opts.bufnr)
+
+			--- Force animation to end if the row no longer exists
+			if line_count < opts.coordinates.e_row + 1 then
+				Snacks.debug(line_count, opts.coordinates.e_row + 1)
+				progress = 1
+				return
+			end
 
 			if opts.coordinates.e_col == 0 then
 				line_end = #line


### PR DESCRIPTION
Error to reproduce:

1. set `slide` to `cursor_moved` animation
2. add `cursor_moved` as an autocmd for `CursorMoved` event
3. prepare a buffer that has more than 20+ lines of code, and then yank
any 2 or above lines
4. quickly do `gg<S-v>G` to select all and `p` or `d` to paste the previous
yanked lines (Need to be very quick, it does'n happen if you slowly
select all and paste in a slow pace)
5. gets `end_col` is out of range error

---

This error happens because the slide animation are running both when you
select from top to bottom (more than 10 lines) and then when pasting the
yanked lines (replace the whole document with the yanked lines and
causes another 10 lines jump). Now it will try to run animation on the
end of the buffer (before paste) and without waiting for the animation,
the replaced text removed the line from the buffer and hence the error
occures.

---

To solve this, I have added more protected calls just for the slide to
prevent weird issue, and make sure to check the current end of file line
number and abort when the line is gone
