### PR TITLE
fix(animation.slide): `ns_id` is invalid when switching buffer very quickly

### DIFF
--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -1,4 +1,4 @@
-*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 March 17
+*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 March 19
 
 ==============================================================================
 Table of Contents                           *undo-glow.nvim-table-of-contents*

--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -22,7 +22,7 @@ function M.animate_clear(opts, timer)
 		end
 
 		for _, id in ipairs(ids) do
-			vim.api.nvim_buf_del_extmark(opts.bufnr, opts.ns, id)
+			pcall(vim.api.nvim_buf_del_extmark, opts.bufnr, opts.ns, id)
 		end
 	end
 	vim.cmd("hi clear " .. opts.hlgroup)
@@ -617,7 +617,7 @@ function M.animate.slide(opts)
 			extmark_opts
 		)
 		if not created_extmark_status then
-			return false -- fallback to fade if extmark creation fails
+			return -- abort if extmark creation fails
 		end
 
 		table.insert(opts.extmark_ids, created_extmark_result)


### PR DESCRIPTION
This change should fix the issue where when we have multiple different
buffers opened, and also using cursor moved with slide animation, when
switching the buffer quickly, it will throw an error of `ns_id` is
invalid.

In this case, we added protected call to `del_extmark` in
`animate_clear` and do not fallback to `fade` animation when it could
not create an `extmark` in `slide` animation.
