### PR TITLE
refactor: move plugin setup to config.lua and update internal config usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1199,7 +1199,7 @@ Moves the highlight horizontally to the right across the text before fading out.
      s_col = opts.coordinates.s_col,
      e_row = opts.coordinates.e_row,
      e_col = opts.coordinates.e_col,
-     priority = opts.config.priority,
+     priority = require("undo-glow.config").config.priority,
      force_edge = opts.state.force_edge,
      window_scoped = opts.state.animation.window_scoped,
     })

--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -1,4 +1,4 @@
-*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 April 08
+*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 April 10
 
 ==============================================================================
 Table of Contents                           *undo-glow.nvim-table-of-contents*
@@ -1046,7 +1046,7 @@ EXAMPLE USING BLINK ANIMATION FROM SOURCE CODE
          s_col = opts.coordinates.s_col,
          e_row = opts.coordinates.e_row,
          e_col = opts.coordinates.e_col,
-         priority = opts.config.priority,
+         priority = require("undo-glow.config").config.priority,
          force_edge = opts.state.force_edge,
          window_scoped = opts.state.animation.window_scoped,
         })

--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -95,7 +95,7 @@ function M.animate.fade(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -146,7 +146,7 @@ function M.animate.fade_reverse(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -196,7 +196,7 @@ function M.animate.blink(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -245,7 +245,7 @@ function M.animate.jitter(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -295,7 +295,7 @@ function M.animate.pulse(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -352,7 +352,7 @@ function M.animate.spring(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -401,7 +401,7 @@ function M.animate.desaturate(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -445,7 +445,7 @@ function M.animate.strobe(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -491,7 +491,7 @@ function M.animate.zoom(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -539,7 +539,7 @@ function M.animate.rainbow(opts)
 		s_col = opts.coordinates.s_col,
 		e_row = opts.coordinates.e_row,
 		e_col = opts.coordinates.e_col,
-		priority = opts.config.priority,
+		priority = require("undo-glow.config").config.priority,
 		force_edge = opts.state.force_edge,
 		window_scoped = opts.state.animation.window_scoped,
 	})
@@ -603,7 +603,7 @@ function M.animate.slide(opts)
 			s_col = opts.coordinates.s_col,
 			e_row = opts.coordinates.e_row,
 			e_col = opts.coordinates.e_col,
-			priority = opts.config.priority,
+			priority = require("undo-glow.config").config.priority,
 			force_edge = opts.state.force_edge,
 			window_scoped = opts.state.animation.window_scoped,
 		})
@@ -751,7 +751,7 @@ function M.animate.slide(opts)
 					s_col = s_col,
 					e_row = row,
 					e_col = e_col,
-					priority = opts.config.priority,
+					priority = require("undo-glow.config").config.priority,
 					force_edge = opts.state.force_edge,
 					window_scoped = opts.state.animation.window_scoped,
 				})
@@ -809,7 +809,7 @@ function M.animate.slide(opts)
 				local new_opts = {
 					hl_group = opts.hlgroup,
 					end_row = row,
-					priority = opts.config.priority,
+					priority = require("undo-glow.config").config.priority,
 				}
 
 				if total_progress <= target_e_col then
@@ -832,7 +832,7 @@ function M.animate.slide(opts)
 								s_col = s_col,
 								e_row = row,
 								e_col = target_e_col,
-								priority = opts.config.priority,
+								priority = require("undo-glow.config").config.priority,
 								force_edge = opts.state.force_edge,
 							})
 						new_opts.virt_text_win_col =

--- a/lua/undo-glow/callback.lua
+++ b/lua/undo-glow/callback.lua
@@ -2,7 +2,6 @@ local M = {}
 
 ---Callback to track changes
 ---@param state UndoGlow.State State
----@param config UndoGlow.Config
 ---@param _err any Error
 ---@param bufnr integer Buffer number
 ---@param _changedtick any Changed tick
@@ -18,7 +17,6 @@ local M = {}
 ---@return boolean
 function M.on_bytes_wrapper(
 	state,
-	config,
 	_err,
 	bufnr,
 	_changedtick,
@@ -53,7 +51,6 @@ function M.on_bytes_wrapper(
 		---@type UndoGlow.HandleHighlight
 		local opts = {
 			bufnr = bufnr,
-			config = config,
 			state = state,
 			s_row = s_row,
 			s_col = s_col,

--- a/lua/undo-glow/config.lua
+++ b/lua/undo-glow/config.lua
@@ -1,5 +1,9 @@
+local M = {}
+
+M.config = {}
+
 ---@type UndoGlow.Config
-local config = {
+local defaults = {
 	animation = {
 		enabled = false,
 		duration = 100,
@@ -41,4 +45,47 @@ local config = {
 	priority = 4096, -- so that it will work with render-markdown.nvim
 }
 
-return config
+---Setup function for undo-glow.
+---Merges the user configuration with the default configuration and sets up the highlights.
+---@param user_config? UndoGlow.Config Optional user configuration.
+---@return nil
+function M.setup(user_config)
+	M.config = vim.tbl_deep_extend("force", defaults, user_config or {})
+
+	local valid_keys = {
+		undo = true,
+		redo = true,
+		yank = true,
+		paste = true,
+		search = true,
+		comment = true,
+		cursor = true,
+	}
+
+	for key in pairs(M.config.highlights) do
+		if not valid_keys[key] then
+			M.config.highlights[key] = nil
+		end
+	end
+
+	local target_map = {
+		undo = "UgUndo",
+		redo = "UgRedo",
+		yank = "UgYank",
+		paste = "UgPaste",
+		search = "UgSearch",
+		comment = "UgComment",
+		cursor = "UgCursor",
+	}
+
+	for key, highlight in pairs(M.config.highlights) do
+		local target = target_map[key]
+		require("undo-glow.highlight").setup_highlight(
+			target,
+			highlight.hl,
+			highlight.hl_color
+		)
+	end
+end
+
+return M

--- a/lua/undo-glow/init.lua
+++ b/lua/undo-glow/init.lua
@@ -2,50 +2,7 @@
 
 local M = {}
 
-M.config = require("undo-glow.config")
-
----Setup function for undo-glow.
----Merges the user configuration with the default configuration and sets up the highlights.
----@param user_config? UndoGlow.Config Optional user configuration.
----@return nil
-function M.setup(user_config)
-	M.config = vim.tbl_deep_extend("force", M.config, user_config or {})
-
-	local valid_keys = {
-		undo = true,
-		redo = true,
-		yank = true,
-		paste = true,
-		search = true,
-		comment = true,
-		cursor = true,
-	}
-
-	for key in pairs(M.config.highlights) do
-		if not valid_keys[key] then
-			M.config.highlights[key] = nil
-		end
-	end
-
-	local target_map = {
-		undo = "UgUndo",
-		redo = "UgRedo",
-		yank = "UgYank",
-		paste = "UgPaste",
-		search = "UgSearch",
-		comment = "UgComment",
-		cursor = "UgCursor",
-	}
-
-	for key, highlight in pairs(M.config.highlights) do
-		local target = target_map[key]
-		require("undo-glow.highlight").setup_highlight(
-			target,
-			highlight.hl,
-			highlight.hl_color
-		)
-	end
-end
+M.setup = require("undo-glow.config").setup
 
 ------- Public API -------
 
@@ -184,11 +141,7 @@ function M.highlight_changes(opts)
 
 	vim.api.nvim_buf_attach(bufnr, false, {
 		on_bytes = function(...)
-			return require("undo-glow.callback").on_bytes_wrapper(
-				state,
-				M.config,
-				...
-			)
+			return require("undo-glow.callback").on_bytes_wrapper(state, ...)
 		end,
 	})
 end
@@ -205,7 +158,6 @@ function M.highlight_region(opts)
 		---@type UndoGlow.HandleHighlight
 		local handle_highlight_opts = {
 			bufnr = bufnr,
-			config = M.config,
 			state = state,
 			s_row = opts.s_row,
 			s_col = opts.s_col,

--- a/lua/undo-glow/types.lua
+++ b/lua/undo-glow/types.lua
@@ -86,7 +86,6 @@
 ---@class UndoGlow.HandleHighlight : UndoGlow.RowCol
 ---@field bufnr integer Buffer number.
 ---@field ns? integer Namespace id.
----@field config UndoGlow.Config Configuration for undo-glow.
 ---@field state UndoGlow.State Current state of the highlight.
 
 ---Represents a region (row/column coordinates) in the buffer.

--- a/lua/undo-glow/utils.lua
+++ b/lua/undo-glow/utils.lua
@@ -97,7 +97,7 @@ function M.handle_highlight(opts)
 			s_col = opts.s_col,
 			e_row = opts.e_row,
 			e_col = opts.e_col,
-			priority = opts.config.priority,
+			priority = require("undo-glow.config").config.priority,
 			force_edge = opts.state.force_edge,
 			window_scoped = opts.state.animation.window_scoped,
 		})
@@ -254,7 +254,7 @@ function M.animate_or_clear_highlights(
 			end_fg = start_fg and require("undo-glow.color").hex_to_rgb(end_fg)
 				or nil,
 			duration = opts.state.animation.duration,
-			config = opts.config,
+			config = require("undo-glow.config").config,
 			state = opts.state,
 			coordinates = {
 				e_col = opts.e_col,
@@ -358,35 +358,37 @@ end
 ---@param opts UndoGlow.HandleHighlight The handle highlight options.
 ---@return UndoGlow.HandleHighlight The validated and updated handle highlight options.
 function M.validate_state_for_highlight(opts)
+	local config = require("undo-glow.config").config
+
 	-- Check animation status and fallback to global
 	if type(opts.state.animation.enabled) ~= "boolean" then
-		opts.state.animation.enabled = opts.config.animation.enabled
+		opts.state.animation.enabled = config.animation.enabled
 	end
 
 	-- Check animation_type and fallback to global
 	if not opts.state.animation.animation_type then
 		opts.state.animation.animation_type =
-			M.get_animation_type(opts.config.animation.animation_type)
+			M.get_animation_type(config.animation.animation_type)
 	end
 
 	-- Check duration and fallback to global
 	if not opts.state.animation.duration then
-		opts.state.animation.duration = opts.config.animation.duration
+		opts.state.animation.duration = config.animation.duration
 	end
 
 	-- Check easing and fallback to global
 	if not opts.state.animation.easing then
-		opts.state.animation.easing = M.get_easing(opts.config.animation.easing)
+		opts.state.animation.easing = M.get_easing(config.animation.easing)
 	end
 
 	-- Check fps and fallback to global
 	if not opts.state.animation.fps then
-		opts.state.animation.fps = opts.config.animation.fps
+		opts.state.animation.fps = config.animation.fps
 	end
 
 	-- Check window_scoped and fallback to global
 	if type(opts.state.animation.window_scoped) ~= "boolean" then
-		opts.state.animation.window_scoped = opts.config.animation.window_scoped
+		opts.state.animation.window_scoped = config.animation.window_scoped
 	end
 
 	return opts

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -2,6 +2,7 @@
 
 local utils = require("undo-glow.utils")
 local spy = require("luassert.spy")
+local config = require("undo-glow.config")
 
 describe("undo-glow.utils", function()
 	describe("get_unique_hlgroup", function()
@@ -518,6 +519,22 @@ describe("undo-glow.utils", function()
 	end)
 
 	describe("validate_state_for_highlight", function()
+		before_each(function()
+			-- Inject a test configuration
+			config.config = {
+				animation = {
+					enabled = true,
+					duration = 150,
+					easing = function(x)
+						return x
+					end,
+					animation_type = "jitter",
+					fps = 30,
+					window_scoped = false,
+				},
+			}
+		end)
+
 		it("should fill missing state animation values from config", function()
 			local opts = {
 				bufnr = 1,
@@ -528,17 +545,6 @@ describe("undo-glow.utils", function()
 						duration = nil,
 						easing = nil,
 						fps = nil,
-					},
-				},
-				config = {
-					animation = {
-						enabled = true,
-						duration = 150,
-						easing = function(x)
-							return x
-						end,
-						animation_type = "jitter",
-						fps = 30,
 					},
 				},
 			}


### PR DESCRIPTION
Internal functions now retrieve the config directly from config.lua
instead of receiving it via parameters. This change is internal and does
not affect the user API.
