### PR TITLE
fix(commands.paste): add support for count (fixes #243)

### DIFF
--- a/doc/undo-glow.nvim.txt
+++ b/doc/undo-glow.nvim.txt
@@ -1,4 +1,4 @@
-*undo-glow.nvim.txt*      For Neovim >= 0.10.0      Last change: 2025 April 16
+*undo-glow.nvim.txt*       For Neovim >= 0.10.0      Last change: 2025 June 03
 
 ==============================================================================
 Table of Contents                           *undo-glow.nvim-table-of-contents*

--- a/lua/undo-glow/commands.lua
+++ b/lua/undo-glow/commands.lua
@@ -46,8 +46,11 @@ function M.paste_below(opts)
 	vim.g.ug_ignore_cursor_moved = true
 	opts = require("undo-glow.utils").merge_command_opts("UgPaste", opts)
 	require("undo-glow").highlight_changes(opts)
+
 	local register = vim.v.register
-	pcall(vim.cmd, string.format('normal! "%sp"', register))
+	local count = vim.v.count > 0 and vim.v.count or 1
+
+	pcall(vim.cmd, string.format('normal! %d"%sp', count, register))
 end
 
 ---Paste above command with highlights.
@@ -57,8 +60,11 @@ function M.paste_above(opts)
 	vim.g.ug_ignore_cursor_moved = true
 	opts = require("undo-glow.utils").merge_command_opts("UgPaste", opts)
 	require("undo-glow").highlight_changes(opts)
+
 	local register = vim.v.register
-	pcall(vim.cmd, string.format('normal! "%sP"', register))
+	local count = vim.v.count > 0 and vim.v.count or 1
+
+	pcall(vim.cmd, string.format('normal! %d"%sP', count, register))
 end
 
 ---Highlight current line after a search is performed.


### PR DESCRIPTION
Add support for count for 'P' and 'p' so that we can use '4p' for
example to paste the same thing 4 times.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Paste operations now support count prefixes, allowing users to paste multiple times in a single command.
- **Documentation**
  - Updated the documentation header with the latest change date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->