### PR TITLE
fix: ensure line are actually string instead of blob before pass to `vim.fn.strdisplay` (fixes #255)

### DIFF
--- a/lua/undo-glow/animation.lua
+++ b/lua/undo-glow/animation.lua
@@ -647,12 +647,16 @@ function M.animate.slide(opts)
 			)
 
 			local line = (success_lines and lines[1] or "") or ""
+
+			line = require("undo-glow.utils").ensure_string(line)
+
 			local line_end = opts.coordinates.e_col
 
 			if opts.coordinates.e_col == 0 then
 				line_end = #line
 			end
 			local line_display = vim.fn.strdisplaywidth(line)
+
 			local win_width = vim.api.nvim_win_get_width(0)
 			local is_force_edge = (
 				type(opts.state.force_edge) == "boolean"
@@ -791,6 +795,8 @@ function M.animate.slide(opts)
 				local success_lines, lines =
 					pcall(vim.api.nvim_buf_get_lines, buf, row, row + 1, false)
 				local line = (success_lines and lines[1] or "") or ""
+
+				line = require("undo-glow.utils").ensure_string(line)
 
 				local line_display = vim.fn.strdisplaywidth(line)
 				if target_e_col == 0 then

--- a/lua/undo-glow/utils.lua
+++ b/lua/undo-glow/utils.lua
@@ -492,6 +492,12 @@ function M.create_extmark_opts(opts)
 			opts.s_row + 1,
 			false
 		)[1] or ""
+
+		-- If it's not a string, might be a `Blob`, we just ignore everything and send back the default extmark options
+		if vim.fn.type(line) ~= 1 then
+			return extmark_opts
+		end
+
 		local text_width = vim.fn.strdisplaywidth(line)
 		local win_width = vim.api.nvim_win_get_width(0)
 		local pad = win_width - text_width
@@ -560,6 +566,16 @@ function M.create_namespace(bufnr, window_scoped)
 	end
 
 	return M.ns
+end
+
+---Ensures that the given value is a string.
+---@param value any The value to be checked.
+---@return string The string representation of the value.
+function M.ensure_string(value)
+	if vim.fn.type(value) == 1 then
+		return value
+	end
+	return ""
 end
 
 return M


### PR DESCRIPTION
Add some check to ensure the string is type 1 (string) instead of type
10 (blob) in certain cases, say binary file. We will just set the line
to "" when it happens, hopefully fixes the case.
